### PR TITLE
added new method SetOutput

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -9,13 +9,14 @@ import (
 	"os"
 	//"path/filepath"
 	"strconv"
+
 	"github.com/IntelliQru/i18n"
 )
 
 type (
 	Controller struct {
 		Ctx *Context
-		T i18n.TFuncHandler
+		T   i18n.TFuncHandler
 	}
 	ControllerInterface interface {
 		Init(ctx *Context)
@@ -26,6 +27,7 @@ type (
 		GetHeader(key string) string
 		SetHeader(key string, val string)
 		SetStatusCode(code int)
+		SetOutput(data []byte)
 
 		Redirect(location string, code int)
 
@@ -70,7 +72,9 @@ func (c Controller) SetHeader(key string, val string) {
 func (c Controller) SetStatusCode(code int) {
 	c.Ctx.code = code
 }
-
+func (c Controller) SetOutput(data []byte) {
+	c.Ctx.output = data
+}
 func (c Controller) Redirect(location string, code int) {
 	c.SetStatusCode(code)
 	c.SetHeader("Location", location)


### PR DESCRIPTION
bugfix: 
Если в контроллере выполнить метод c.Ctx.Response.Write, то в консоль выводится сообщение "http: multiple response.WriteHeader calls"

Причины:

Когда выполняется метод c.Ctx.Response.Write у c.Ctx.Response атрибуту wroteHeader присваивается значение true. В следствии чего при выполнении метода контроллера "exec", а именно инструкции "c.Ctx.Response.WriteHeader(c.Ctx.code)" в консоль выводится сообщение "http: multiple response.WriteHeader calls"

про "wroteHeader" см. 
https://golang.org/src/net/http/server.go?h=wroteHeader#L1052
https://golang.org/src/net/http/server.go?h=wroteHeader#L1510
